### PR TITLE
API for specifying the event time against `EventGauge` metrics

### DIFF
--- a/BosunReporter/Metrics/EventGauge.cs
+++ b/BosunReporter/Metrics/EventGauge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using BosunReporter.Infrastructure;
+using System;
 
 namespace BosunReporter.Metrics
 {
@@ -26,6 +27,11 @@ namespace BosunReporter.Metrics
         {
             AssertAttached();
             _serializedMetrics.Add(ToJson("", value, MetricsCollector.GetUnixTimestamp()));
+        }
+        public void Record(double value, DateTime time)
+        {
+            AssertAttached();
+            _serializedMetrics.Add(ToJson("", value, MetricsCollector.GetUnixTimestamp(time)));
         }
     }
 }

--- a/BosunReporter/MetricsCollector.cs
+++ b/BosunReporter/MetricsCollector.cs
@@ -636,7 +636,11 @@ namespace BosunReporter
 
         internal static string GetUnixTimestamp()
         {
-            return ((long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds).ToString("D");
+            return GetUnixTimestamp(DateTime.UtcNow);
+        }
+        internal static string GetUnixTimestamp(DateTime time)
+        {
+            return ((long)(time - UnixEpoch).TotalMilliseconds).ToString("D");
         }
 
         private IEnumerable<string> GetSerializedMetrics()


### PR DESCRIPTION
 (note: does not support aggregates); this is to facilitate backfill capability on simple data; I also considered an artificial clock API, but concluded that this was the most appropriate implementation

