### PR TITLE
Format doubles with InvariantCulture

### DIFF
--- a/BosunReporter/Infrastructure/MetricWriter.cs
+++ b/BosunReporter/Infrastructure/MetricWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -108,7 +109,7 @@ namespace BosunReporter.Infrastructure
 
         void Append(double d)
         {
-            Append(d.ToString("R")); // todo - use Grisu
+            Append(d.ToString("R", CultureInfo.InvariantCulture)); // todo - use Grisu
         }
 
         void Append(DateTime timestamp)


### PR DESCRIPTION
Thanks for an awesome project!
In production we run servers with swedish culture. This bit us when trying to send `double` values to Bosun, as they were incorrectly formatted with a comma instead of a dot. 

This PR prevents generating invalid JSON if the host system runs on a culture where `double.ToString` generates a comma (,) instead of a dot (.) by always using the InvariantCulture.