### PR TITLE
Related to AW-346 - Put reading (metric) name in exception

### DIFF
--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -307,7 +307,7 @@ namespace StackExchange.Metrics.Handlers
                             "Span was not big enough to write metric value"
                         );
 
-                        ex.Data.Add("Name", reading.Name.ToString());
+                        ex.Data.Add("Name", reading.Name);
                         ex.Data.Add("Value", valueAsLong.ToString());
                         ex.Data.Add("Size", valueLength.ToString());
                         throw ex;
@@ -320,7 +320,7 @@ namespace StackExchange.Metrics.Handlers
                         "Span was not big enough to write metric value"
                     );
 
-                    ex.Data.Add("Name", reading.Name.ToString());
+                    ex.Data.Add("Name", reading.Name);
                     ex.Data.Add("Value", value.ToString("f5"));
                     ex.Data.Add("Size", valueLength.ToString());
                     throw ex;

--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -307,6 +307,7 @@ namespace StackExchange.Metrics.Handlers
                             "Span was not big enough to write metric value"
                         );
 
+                        ex.Data.Add("Name", reading.Name.ToString());
                         ex.Data.Add("Value", valueAsLong.ToString());
                         ex.Data.Add("Size", valueLength.ToString());
                         throw ex;
@@ -319,6 +320,7 @@ namespace StackExchange.Metrics.Handlers
                         "Span was not big enough to write metric value"
                     );
 
+                    ex.Data.Add("Name", reading.Name.ToString());
                     ex.Data.Add("Value", value.ToString("f5"));
                     ex.Data.Add("Size", valueLength.ToString());
                     throw ex;


### PR DESCRIPTION
This is to add more context to the exception thrown, specifically the metric name that is invalid.

Datadog is throwing exceptions for negative gauge values that were being pushed, but we don't know for which fields.