### PR TITLE
Fix negative values being sent to Datadog

### DIFF
--- a/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
+++ b/src/StackExchange.Metrics/Handlers/StatsdMetricHandler.cs
@@ -251,9 +251,10 @@ namespace StackExchange.Metrics.Handlers
             var length = encoding.GetByteCount(reading.Name) + s_colon.Length;
 
             // calculate the length needed to render the value
-            var value = reading.Value;
+            var value = Math.Abs(reading.Value);
+            var valueIsNegative = reading.Value < 0;
             var valueIsWhole = value % 1 == 0;
-            int valueLength = 1; // first digit
+            int valueLength = valueIsNegative ? 2 : 1; // first digit, plus negative sign if negative
             if (!valueIsWhole)
             {
                 valueLength += 1 + ValueDecimals; // + decimal point + decimal digits
@@ -308,7 +309,7 @@ namespace StackExchange.Metrics.Handlers
                         );
 
                         ex.Data.Add("Name", reading.Name);
-                        ex.Data.Add("Value", valueAsLong.ToString());
+                        ex.Data.Add("Value", reading.Value.ToString());
                         ex.Data.Add("Size", valueLength.ToString());
                         throw ex;
                     }
@@ -321,7 +322,7 @@ namespace StackExchange.Metrics.Handlers
                     );
 
                     ex.Data.Add("Name", reading.Name);
-                    ex.Data.Add("Value", value.ToString("f5"));
+                    ex.Data.Add("Value", reading.Value.ToString("f5"));
                     ex.Data.Add("Size", valueLength.ToString());
                     throw ex;
                 }

--- a/tests/StackExchange.Metrics.Tests/StatsdMetricHandlerTests.cs
+++ b/tests/StackExchange.Metrics.Tests/StatsdMetricHandlerTests.cs
@@ -30,6 +30,9 @@ namespace StackExchange.Metrics.Tests
         [InlineData(2.443d)]
         [InlineData(1.1234457d)]
         [InlineData(9.1234457d)]
+        [InlineData(-1d)]
+        [InlineData(-2.443d)]
+        [InlineData(-9.1234457d)]
         public async Task UdpUri_Counter_ReceivesValidStatsd(double value)
         {
             var port = (ushort)_rng.Next(1024, 65535);


### PR DESCRIPTION
The negative sign for numbers is not taken into account when calculating the size of the encoding buffer, so writing negative values causes utf8writer to not be able to format it into the buffer.

This fixes the calculation by checking if the number is negative, and using the correct value when throwing an exception.